### PR TITLE
Format with rustfmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,13 @@
 //! Parses JSON into [`serde_json_borrow::Value<'ctx>`](Value) from `&'ctx str`.
 //!
 //! The default [serde_json](https://github.com/serde-rs/json) parses into an owned `serde_json::Value`.
-//! In cases where the DOM representation is just an intermediate struct, parsing into owned `serde_json::Value`
-//! can cause a lot of overhead. [`serde_json_borrow::Value<'ctx>`](Value) borrows the `Strings`
-//! instead.
+//! In cases where the DOM representation is just an intermediate struct, parsing into owned
+//! `serde_json::Value` can cause a lot of overhead. [`serde_json_borrow::Value<'ctx>`](Value)
+//! borrows the `Strings` instead.
 //!
-//! Additionally it pushes the (key,value) for JSON objects into a `Vec` instead of putting the values into a `BTreeMap`.
-//! Access works via an iterator, which has the same API when iterating the `BTreeMap`.
+//! Additionally it pushes the (key,value) for JSON objects into a `Vec` instead of putting the
+//! values into a `BTreeMap`. Access works via an iterator, which has the same API when iterating
+//! the `BTreeMap`.
 //!
 //! The primary benefit of using `serde_json_borrow` is a higher JSON _deserialization performance_
 //! due to less allocations. By borrowing a DOM, the library ensures that no additional memory is


### PR DESCRIPTION
Generated by `cargo fmt`.

d4c2e49b5277cf4536479ad89e92ae1855a987a7 was not properly formatted according to rustfmt. That's problematic because it prevents future contributors from having an easy way to conform with this repo's nonstandard formatting configuration.