### PR TITLE
refactor: extend returned lifetimes

### DIFF
--- a/src/object_vec.rs
+++ b/src/object_vec.rs
@@ -39,7 +39,7 @@ impl<'ctx> ObjectAsVec<'ctx> {
     /// methods instead. This could be a problem with feature unification, when one crate uses it
     /// as &str and another uses it as Cow<str>, both will get Cow<str?
     #[inline]
-    pub fn as_vec(&self) -> &Vec<(KeyStrType, Value)> {
+    pub fn as_vec(&self) -> &Vec<(KeyStrType, Value<'ctx>)> {
         &self.0
     }
 
@@ -55,7 +55,7 @@ impl<'ctx> ObjectAsVec<'ctx> {
     /// As this is backed by a Vec, this searches linearly through the Vec as may be much more
     /// expensive than a `Hashmap` for larger Objects.
     #[inline]
-    pub fn get(&self, key: &str) -> Option<&Value> {
+    pub fn get(&self, key: &str) -> Option<&Value<'ctx>> {
         self.0
             .iter()
             .find_map(|(k, v)| if *k == key { Some(v) } else { None })
@@ -79,7 +79,7 @@ impl<'ctx> ObjectAsVec<'ctx> {
     /// As this is backed by a Vec, this searches linearly through the Vec as may be much more
     /// expensive than a `Hashmap` for larger Objects.
     #[inline]
-    pub fn get_key_value(&self, key: &str) -> Option<(&str, &Value)> {
+    pub fn get_key_value(&self, key: &str) -> Option<(&str, &Value<'ctx>)> {
         self.0.iter().find_map(|(k, v)| {
             if *k == key {
                 Some((k.as_ref(), v))
@@ -91,7 +91,7 @@ impl<'ctx> ObjectAsVec<'ctx> {
 
     /// An iterator visiting all key-value pairs
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &Value)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Value<'ctx>)> {
         self.0.iter().map(|(k, v)| (k.as_ref(), v))
     }
 
@@ -115,7 +115,7 @@ impl<'ctx> ObjectAsVec<'ctx> {
 
     /// An iterator visiting all values
     #[inline]
-    pub fn values(&self) -> impl Iterator<Item = &Value> {
+    pub fn values(&self) -> impl Iterator<Item = &Value<'ctx>> {
         self.0.iter().map(|(_, v)| v)
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -188,7 +188,7 @@ impl<'ctx> Value<'ctx> {
     }
 
     /// If the Value is an Array, returns the associated Array. Returns None otherwise.
-    pub fn as_array(&self) -> Option<&[Value<'_>]> {
+    pub fn as_array(&self) -> Option<&[Value<'ctx>]> {
         match self {
             Value::Array(arr) => Some(arr),
             _ => None,
@@ -196,7 +196,7 @@ impl<'ctx> Value<'ctx> {
     }
 
     /// If the Value is an Object, returns the associated Object. Returns None otherwise.
-    pub fn as_object(&self) -> Option<&ObjectAsVec> {
+    pub fn as_object(&self) -> Option<&ObjectAsVec<'ctx>> {
         match self {
             Value::Object(obj) => Some(obj),
             _ => None,


### PR DESCRIPTION
Current lifetimes for some methods on Value are tied to the `&self` while it actually returns the values with `'ctx` lifetime.

Having `'ctx` lifetime could simplify usage of the code that is building trait abstraction that should be implemented by `serde_json-borrow` since the current implementation requires tackling with generic lifetimes ([example](https://github.com/tailcallhq/tailcall/pull/2586/files#diff-f32243447859f277f06b5a1d63dd869949c74ce831527e2fcbeca68767321f5cR25))