### PR TITLE
feat: Add get_key_value_at method for O(1) lookup in ObjectAsVec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,6 @@ mod value;
 #[cfg(feature = "cowkeys")]
 mod cowstr;
 
-pub use object_vec::{KeyStrType, ObjectAsVec, ObjectAsVec as Map};
+pub use object_vec::{KeyStrType, ObjectAsVec, ObjectAsVec as Map, ObjectEntry};
 pub use ownedvalue::OwnedValue;
 pub use value::Value;


### PR DESCRIPTION
I have a need to partition ObjectAsVec into different collections in jsonlogprint[^1] and it's convenient to be able to do it via indexes, so this adds a method to allow fast lookup after a search.

The `get_entry` and `ObjectEntry` items are convenience features for users, I could omit them from this PR if you'd prefer to encourage people to use an `iter().enumerate().find()` api themselves.

[^1]: https://github.com/quodlibetor/jsonlogprint