### PR TITLE
Do not tie index lifetime to value lifetime

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -109,7 +109,7 @@ impl<'ctx> Value<'ctx> {
     /// assert_eq!(data.get("a").get("b"), &Value::Null);
     /// ```
     #[inline]
-    pub fn get<I: Index<'ctx>>(&'ctx self, index: I) -> &'ctx Value<'ctx> {
+    pub fn get<I: Index>(&self, index: I) -> &Value<'ctx> {
         static NULL: Value = Value::Null;
         index.index_into(self).unwrap_or(&NULL)
     }


### PR DESCRIPTION
The index lifetime is not the same as the value lifetime. Tying them together means that it is not possible to look up a value using an index with a shorter lifetime.

Because this changes the signature of the public Index trait, it is a breaking change, though probably nobody would notice.